### PR TITLE
update python version used by heroku

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.7.5


### PR DESCRIPTION
heroku doesn't use python 3.5.2 anymore
check: https://devcenter.heroku.com/articles/python-support